### PR TITLE
Enable system.img flashing

### DIFF
--- a/recovery/root/fstab.samsungexynos9810
+++ b/recovery/root/fstab.samsungexynos9810
@@ -3,7 +3,7 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-#/dev/block/platform/11120000.ufs/by-name/SYSTEM         /system     ext4    ro,errors=panic                                             wait
+/dev/block/platform/11120000.ufs/by-name/SYSTEM         /system     emmc    defaults defaults
 /dev/block/platform/11120000.ufs/by-name/CACHE          /cache      ext4    noatime,nosuid,nodev,noauto_da_alloc,discard,journal_checksum,data=ordered,errors=panic       wait,check
 /dev/block/platform/11120000.ufs/by-name/USERDATA       /data       ext4    noatime,nosuid,nodev,noauto_da_alloc,discard,journal_checksum,data=ordered,errors=panic       wait,check,forceencrypt=footer,quota
 /dev/block/platform/11120000.ufs/by-name/EFS            /efs        ext4    noatime,nosuid,nodev,noauto_da_alloc,discard,journal_checksum,data=ordered,errors=panic       wait,check


### PR DESCRIPTION
This is useful, for instance to flash a Treble GSI, which is currently packaged as a sparse image.